### PR TITLE
add GitHub Actions workflow to close invalid pull requests

### DIFF
--- a/.github/workflows/close-invaild-pr.yml
+++ b/.github/workflows/close-invaild-pr.yml
@@ -1,0 +1,28 @@
+name: Close Invalid PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  close_invalid_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v3
+
+    - name: Check PR Branch
+      id: check_branch
+      run: |
+        BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+        if [[ "$BASE_BRANCH" != "develop" && "$BASE_BRANCH" != hotfix/* ]]; then
+          echo "invalid=true" >> $GITHUB_ENV
+        else
+          echo "invalid=false" >> $GITHUB_ENV
+        fi
+
+    - name: Close PR if invalid
+      if: env.invalid == 'true'
+      run: |
+        gh pr close ${{ github.event.pull_request.number }} --comment "Closing PR: Only 'develop' or 'hotfix/*' branches are allowed."


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically close invalid pull requests. The workflow checks if the pull request is targeting branches other than 'develop' or 'hotfix/*' and closes them if they are invalid.

Key changes include:

* Added a new workflow file `.github/workflows/close-invaild-pr.yml` to automate the process of closing invalid pull requests.

Workflow details:

* The workflow is triggered on pull request events of type 'opened' and 'synchronize'.
* It includes a job that checks out the repository, verifies the target branch of the pull request, and closes the pull request if the branch is not 'develop' or 'hotfix/*'.